### PR TITLE
 default literal encoding is UTF-8 since ruby2.0.0-p0. So It should be declare ASCII-8BIT explicitly. ref #4

### DIFF
--- a/lib/image_size.rb
+++ b/lib/image_size.rb
@@ -1,3 +1,5 @@
+# -- coding: ASCII-8BIT --
+#
 require 'stringio'
 require 'tempfile'
 


### PR DESCRIPTION
 default literal encoding is UTF-8 since ruby2.0.0-p0. So It should be declare ASCII-8BIT explicitly. ref #4
