### PR TITLE
add file_size as a method

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Add `byte_size` method to expose the size of the image data in bytes [@dgodd](https://github.com/dgodd)
+* Add `byte_size` method to expose the size of the image data in bytes [#27](https://github.com/toy/image_size/pull/27) [@dgodd](https://github.com/dgodd)
 
 ## v3.4.0 (2024-01-16)
 

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Add `byte_size` method to expose the size of the image data in bytes [@dgodd](https://github.com/dgodd)
+
 ## v3.4.0 (2024-01-16)
 
 * Provide access to media types using media_type and media_types methods [#22](https://github.com/toy/image_size/issues/22) [@toy](https://github.com/toy)

--- a/lib/image_size.rb
+++ b/lib/image_size.rb
@@ -51,6 +51,7 @@ class ImageSize
     Reader.open(data) do |ir|
       @format = detect_format(ir)
       @width, @height = send("size_of_#{@format}", ir) if @format
+      @byte_size = ir.byte_size
     end
   end
 
@@ -64,6 +65,8 @@ class ImageSize
   # Image height
   attr_reader :height
   alias_method :h, :height
+
+  attr_reader :byte_size
 
   # get image width and height as an array which to_s method returns "#{width}x#{height}"
   def size

--- a/lib/image_size/seekable_io_reader.rb
+++ b/lib/image_size/seekable_io_reader.rb
@@ -12,6 +12,10 @@ class ImageSize
       @chunks = {}
     end
 
+    def byte_size
+      @io.size
+    end
+
   private
 
     def chunk(i)

--- a/lib/image_size/stream_io_reader.rb
+++ b/lib/image_size/stream_io_reader.rb
@@ -11,6 +11,12 @@ class ImageSize
       @chunks = []
     end
 
+    def byte_size
+      return nil unless @io.respond_to?(:stat) && @io.stat.file?
+
+      @io.stat.size
+    end
+
   private
 
     def chunk(i)

--- a/lib/image_size/string_reader.rb
+++ b/lib/image_size/string_reader.rb
@@ -17,5 +17,9 @@ class ImageSize
     def [](offset, length)
       @string[offset, length]
     end
+
+    def byte_size
+      @string.bytesize
+    end
   end
 end

--- a/lib/image_size/uri_reader.rb
+++ b/lib/image_size/uri_reader.rb
@@ -98,7 +98,7 @@ class ImageSize
           when Net::HTTPRedirection
             uri += response['location']
           when Net::HTTPPartialContent
-            m = response['content-range'].match(%r{bytes\s+\d+-\d+/(\d+)}) if response['content-range']
+            m = response['content-range'].match(%r{\bbytes\s+\d+-\d+/(\d+)}i) if response['content-range']
             byte_size = m[1].to_i if m
             return yield RangeReader.new(http, uri.request_uri, response.body, byte_size)
           when Net::HTTPRequestedRangeNotSatisfiable

--- a/lib/image_size/uri_reader.rb
+++ b/lib/image_size/uri_reader.rb
@@ -25,9 +25,12 @@ class ImageSize
     class BodyReader # :nodoc:
       include ChunkyReader
 
+      attr_reader :byte_size
+
       def initialize(response)
         @body = String.new
         @body_reader = response.to_enum(:read_body)
+        @byte_size = response.content_length
       end
 
       def [](offset, length)
@@ -46,10 +49,13 @@ class ImageSize
     class RangeReader # :nodoc:
       include HTTPChunkyReader
 
-      def initialize(http, request_uri, chunk0)
+      attr_reader :byte_size
+
+      def initialize(http, request_uri, chunk0, byte_size)
         @http = http
         @request_uri = request_uri
         @chunks = { 0 => chunk0 }
+        @byte_size = byte_size
       end
 
       def chunk(i)
@@ -92,7 +98,9 @@ class ImageSize
           when Net::HTTPRedirection
             uri += response['location']
           when Net::HTTPPartialContent
-            return yield RangeReader.new(http, uri.request_uri, response.body)
+            m = response['content-range'].match(%r{bytes\s+\d+-\d+/(\d+)}) if response['content-range']
+            byte_size = m[1].to_i if m
+            return yield RangeReader.new(http, uri.request_uri, response.body, byte_size)
           when Net::HTTPRequestedRangeNotSatisfiable
             return yield StringReader.new('')
           else

--- a/spec/image_size_spec.rb
+++ b/spec/image_size_spec.rb
@@ -79,6 +79,7 @@ describe ImageSize do
           size: size,
           media_type: media_type,
           media_types: media_types,
+          byte_size: file_size,
         }
       end
       let(:file_data){ File.binread(path) }
@@ -119,6 +120,8 @@ describe ImageSize do
       end
 
       context 'given as unseekable IO' do
+        let(:attributes){ super().merge(byte_size: nil) }
+
         it 'gets format and dimensions' do
           IO.popen(%W[cat #{path}].shelljoin, 'rb') do |io|
             image_size = ImageSize.new(io)


### PR DESCRIPTION
I use ImageSize in some of my projects, and I have started using your new experimental 'http' support, specifically using range support. I frequently like to always have the file size, which can be obtained from http headers (including on ranges).

I don't know if you are interested in such functionality, but I have added it, partially to see how well it would play out in the code base. If you are interested in this functionality, I'm open to any suggestions you have